### PR TITLE
Added link to mtgjson.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,8 @@ You can also change the country e.g. `sold_in_uk=1`, `sold_in_de=1`, etc.
   * [MTG LEB Set + Extras](http://mtgjson.com/json/LEB-x.json)
   * [MTG ARN Set](http://mtgjson.com/json/ARN.json)
   * [MTG ARN Set + Extras](http://mtgjson.com/json/ARN-x.json)
-  
-> Protip: http://mtgjson.com Lists many more Magic: The Gathering card data sets, as well as zipped versions of all sets.
+
+> Protip: [http://mtgjson.com](http://mtgjson.com) lists many more Magic: The Gathering card data sets, as well as zipped versions of all sets.
 
 ## GitHub API
 * [Emojis](https://api.github.com/emojis)

--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ You can also change the country e.g. `sold_in_uk=1`, `sold_in_de=1`, etc.
 ## Gaming
 * [BattleField 4](http://bf4stats.com/api)
   * [Online Players](http://api.bf4stats.com/api/onlinePlayers?output=json)
+* [Magic: The Gathering](magic.wizards.com)
+  * [MTG JSON Card Data](mtgjson.com)
 
 ## GitHub API
 * [Emojis](https://api.github.com/emojis)

--- a/README.md
+++ b/README.md
@@ -178,7 +178,14 @@ You can also change the country e.g. `sold_in_uk=1`, `sold_in_de=1`, etc.
 * [BattleField 4](http://bf4stats.com/api)
   * [Online Players](http://api.bf4stats.com/api/onlinePlayers?output=json)
 * [Magic: The Gathering](magic.wizards.com)
-  * [MTG JSON Card Data](mtgjson.com)
+  * [MTG LEA Set](http://mtgjson.com/json/LEA.json)
+  * [MTG LEA Set + Extras](http://mtgjson.com/json/LEA-x.json)
+  * [MTG LEB Set](http://mtgjson.com/json/LEB.json)
+  * [MTG LEB Set + Extras](http://mtgjson.com/json/LEB-x.json)
+  * [MTG ARN Set](http://mtgjson.com/json/ARN.json)
+  * [MTG ARN Set + Extras](http://mtgjson.com/json/ARN-x.json)
+  
+> Protip: http://mtgjson.com Lists many more Magic: The Gathering card data sets, as well as zipped versions of all sets.
 
 ## GitHub API
 * [Emojis](https://api.github.com/emojis)


### PR DESCRIPTION
Instead of linking to individual sets, I think it's better to link to the main site page. From there, it's easy to find links to get all sets or any individual set.

#21 