### PR TITLE
Added Esperanto Randomizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,7 @@ You can also change the country e.g. `sold_in_uk=1`, `sold_in_de=1`, etc.
 ## Other
 * [Wikidata](https://dumps.wikimedia.org/other/wikidata/) *Gigabytes of Gzipped JSON*
 * [Industries](https://www.sajari.com/free-data/industries.json)
+* [Esperanto Words Set](https://api.eo.kevineaton.net/random) *You can drop the /random to get the full list (~700k)*
 
 ## More Awesome Lists
 * [Awesome](https://github.com/sindresorhus/awesome) *(The OG List)*


### PR DESCRIPTION
Added a link to an API that can give all of the current Esperanto words or a random set. The repository for the actual server can be found at https://github.com/kevineaton/go-esperanto