### PR TITLE
Adding Pokémon API from pokeapi.co

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,8 @@ You can also change the country e.g. `sold_in_uk=1`, `sold_in_de=1`, etc.
 ## Gaming
 * [BattleField 4](http://bf4stats.com/api)
   * [Online Players](http://api.bf4stats.com/api/onlinePlayers?output=json)
+* [Pokémon](https://pokeapi.co/docsv2/)
+  * [Pokémon by Number](http://pokeapi.co/api/v2/pokemon/1/) *(Replace `1` with desired Pokémon number)*
 * [Magic: The Gathering](magic.wizards.com)
   * [MTG LEA Set](http://mtgjson.com/json/LEA.json)
   * [MTG LEA Set + Extras](http://mtgjson.com/json/LEA-x.json)


### PR DESCRIPTION
Adds the ability to search by Pokémon number from https://pokeapi.co/.