### PR TITLE
Add HearthstoneJSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ You can also change the country e.g. `sold_in_uk=1`, `sold_in_de=1`, etc.
   * [MTG LEB Set + Extras](http://mtgjson.com/json/LEB-x.json)
   * [MTG ARN Set](http://mtgjson.com/json/ARN.json)
   * [MTG ARN Set + Extras](http://mtgjson.com/json/ARN-x.json)
+* [Hearthstone](https://hearthstonejson.com/)
+  * [All cards, in every language](https://api.hearthstonejson.com/v1/latest/all/cards.json)
+  * [All cards, in English](https://api.hearthstonejson.com/v1/latest/enUS/cards.json)
+  * [Collectible cards, in English](https://api.hearthstonejson.com/v1/latest/enUS/cards.collectible.json)
+  * [Card backs, in English](https://api.hearthstonejson.com/v1/latest/enUS/cardbacks.json)
 * [Steam Player Number](https://api.steampowered.com/ISteamUserStats/GetNumberOfCurrentPlayers/v0001/?format=json&appid=0)
 
 > Protip: [http://mtgjson.com](http://mtgjson.com) lists many more Magic: The Gathering card data sets, as well as zipped versions of all sets.


### PR DESCRIPTION
There is a cards.json, cards.collectible.json and cardbacks.json for every game patch to date. By using "latest", it automatically redirects to the latest patch.

### cards.json
Every card in the game, and since everything in Hearthstone is a card, this includes non-playable cards such as those created by spells
### cards.collectible.json
Cards that can be collected, as well as heroes.
### cardbacks.json
Details of all the available card backs.

Each JSON file is available either in English or in every available language, but the latter is quite large, so I only included one example.