### PR TITLE
Delete USA.gov links from README.md (issue 125)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,34 +260,6 @@ You can also change the country e.g. `sold_in_uk=1`, `sold_in_de=1`, etc.
 
 > Protip: use offset=1000 to view the next 1000 bills. [GovTrack](https://www.govtrack.us/) provides a [powerful API](https://www.govtrack.us/developers/api) for viewing data on Congress, roll calls, and bills.
 
-* USA.gov
-  * [Corporate Consumer Contact Directory](https://www.usa.gov/api/USAGovAPI/corporate/contacts.json/contacts)
-  * [Federal Agency Contact Directory](https://www.usa.gov/api/USAGovAPI/contacts.json/contacts)
-    * [FBI](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/49278)
-    * [CIA](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/52590)
-    * [DEA](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/52688)
-    * [TSA](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/48143)
-    * [NSA](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/49546)
-    * [DOJ](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/52686)
-    * [DOD](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/49229)
-    * [FEMA](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/48042)
-    * [DHS](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/49022)
-    * [FDA](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/48058)
-    * [NASA](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/49476)
-    * [Secret Service](https://www.usa.gov/api/USAGovAPI/contacts.json/contact/49660)
-  * Social Media Accounts
-    * [USDA](http://registry.usa.gov/accounts.json?agency_id=usda)
-    * [FBI](http://registry.usa.gov/accounts.json?agency_id=fbi)
-    * [CIA](http://registry.usa.gov/accounts.json?agency_id=cia)
-    * [NASA](http://registry.usa.gov/accounts.json?agency_id=nasa)
-    * [FEMA](http://registry.usa.gov/accounts.json?agency_id=fema)
-    * [DHS](http://registry.usa.gov/accounts.json?agency_id=dhs)
-  * [Mobile Apps](http://apps.usa.gov/apps-gallery/api/galleries.json)
-    * [FBI](http://apps.usa.gov/apps-gallery/api/registrations.json?Name=*FBI*)
-    * [CIA](http://apps.usa.gov/apps-gallery/api/registrations.json?Name=*CIA*)
-    * [NASA](http://apps.usa.gov/apps-gallery/api/registrations.json?Name=*NASA*)
-    * [FEMA](http://apps.usa.gov/apps-gallery/api/registrations.json?Name=*FEMA*)
-    * [TSA](http://apps.usa.gov/apps-gallery/api/registrations.json?Name=*TSA*)
 * Department of Justice
   * [Blog Entries](http://www.justice.gov/api/v1/blog_entries.json?amp%3Bpagesize=2)
   * [Press Releases](http://www.justice.gov/api/v1/press_releases.json?pagesize=2)


### PR DESCRIPTION
From  #125 & #21 
Based on the relatively recent publication (https://www.usa.gov/developer#item-211492) and some combing through links provided here and following through to their FAQs and respective github sites, it appears that all API access related to the usa.gov site is no longer available - at least in an unauthenticated format, therefore, should be removed from this list of awesome APIs.