### PR TITLE
Los Angeles Crime dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ _Sponsored link:_ [Front End Developer Jobs](https://www.bootstrapcdn.com/jobs/?
   * [List of Forces](https://data.police.uk/api/forces)
 * [DATA.GOV](https://www.data.gov/local/)
   * [Chicago (historical data since 2001)](https://data.cityofchicago.org/api/views/ijzp-q8t2/rows.json?accessType=DOWNLOAD)
+  * [Los Angeles (historical data since 2010)](https://data.lacity.org/api/views/y8tr-7khq/rows.json?accessType=DOWNLOAD)
 
 ## Currency
 * [Foreign Exchange Rates](https://exchangeratesapi.io/)


### PR DESCRIPTION
Added a link to a public dataset next to Chicago, for los angeles.