### PR TITLE
Updated/removed broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,13 +55,11 @@ _Sponsored link:_ [Front End Developer Jobs](https://www.bootstrapcdn.com/jobs/?
   * [Los Angeles (historical data since 2010)](https://data.lacity.org/api/views/y8tr-7khq/rows.json?accessType=DOWNLOAD)
 
 ## Currency
-* [VAT rates for EU](http://jsonvat.com/)
 * [Exchange Rate API](https://www.exchangerate-api.com)
   * [USD](https://api.exchangerate-api.com/v4/latest/USD)
   * [GBP](https://api.exchangerate-api.com/v4/latest/GBP)
 
 ## Gaming
-* [BattleField 4 Online Players](http://api.bf4stats.com/api/onlinePlayers?output=json)
 * [Pokémon](https://pokeapi.co/docsv2/)
   * [Pokémon by Number](http://pokeapi.co/api/v2/pokemon/1/) *(Replace `1` with desired Pokémon number)*
   * [Types](http://pokeapi.co/api/v2/type/1/) *(Replace `1` with another number to retrieve different type)*
@@ -83,9 +81,6 @@ _Sponsored link:_ [Front End Developer Jobs](https://www.bootstrapcdn.com/jobs/?
 * [Meta](https://api.github.com/meta)
 
 ## Government
-* [Trade.gov](http://developer.trade.gov/api/trade-apis.json)
-  * [Business Service Providers](http://developer.trade.gov/api/business-service-providers.json)
-  * [Consumer Complaint Database](http://data.consumerfinance.gov/api/views.json)
 * United States Politicians
   * [Current US Senators](https://www.govtrack.us/api/v2/role?current=true&role_type=senator)
   * [Current US Representatives](https://www.govtrack.us/api/v2/role?current=true&role_type=representative&limit=438)
@@ -105,14 +100,6 @@ _Sponsored link:_ [Front End Developer Jobs](https://www.bootstrapcdn.com/jobs/?
 
 > Pro Tip: you can do **a lot** more at [http://parliamentdata.ca/](http://parliamentdata.ca/)
 
-* EU Lobbying Transparency Register
-  * [Country](http://api.lobbyfacts.eu/api/1/country)
-  * [Entity](http://api.lobbyfacts.eu/api/1/entity)
-  * [Representative](http://api.lobbyfacts.eu/api/1/representative)
-  * [Person](http://api.lobbyfacts.eu/api/1/person)
-  * [Category](http://api.lobbyfacts.eu/api/1/category)
-  * [Financial](http://api.lobbyfacts.eu/api/1/financial_data)
-  * [Accreditation](http://api.lobbyfacts.eu/api/1/accreditation)
 * Government of India
   * [State Codes](http://vocab.nic.in/rest.php/states/json)
   * [Consumer Price Index](https://data.gov.in/node/1084041/datastore/export/json)
@@ -123,11 +110,7 @@ _Sponsored link:_ [Front End Developer Jobs](https://www.bootstrapcdn.com/jobs/?
   * [ABC Local Stations](http://data.gov.au/geoserver/abc-local-stations/wfs?request=GetFeature&typeName=ckan_d534c0e9_a9bf_487b_ac8f_b7877a09d162&outputFormat=json)
   * [VIC Police Station Locations](http://data.gov.au/geoserver/police-station-locations/wfs?request=GetFeature&typeName=762b47b2_e706_4cab_b0c7_cf8e406aefc1&outputFormat=json)
   * [Museums Victoria Collections](https://collections.museumvictoria.com.au/api/search)
-* Amsterdam
-  * [Shops](http://open.datapunt.amsterdam.nl/Shoppen.json)
-  * [Food and Drinks](http://open.datapunt.amsterdam.nl/EtenDrinken.json)
-  * [Museums and Galleries](http://open.datapunt.amsterdam.nl/MuseaGalleries.json)
-
+* [Amsterdam](https://api.data.amsterdam.nl/api/) ([Google translation](https://translate.google.com/translate?sl=nl&tl=en&u=https%3A%2F%2Fapi.data.amsterdam.nl%2Fapi%2F))
 * Spain
   * [Province of Madrid Municipalities](https://datos.comunidad.madrid/catalogo/dataset/032474a0-bf11-4465-bb92-392052962866/resource/301aed82-339b-4005-ab20-06db41ee7017/download/municipio_comunidad_madrid.json)
   * [Province of Barcelona Municipalities](https://do.diba.cat/api/dataset/municipis/format/json2)
@@ -225,8 +208,7 @@ _Sponsored link:_ [Front End Developer Jobs](https://www.bootstrapcdn.com/jobs/?
 > Pro Tip: you can append `.json` to any subreddit url.
 
 ## Travel
-* [Global Airfields](https://ckannet-storage.commondatastorage.googleapis.com/2014-12-13T15:15:31.729Z/airfields.json)
-* [Monthly Airline Delays by Airport, 2003-2016](https://think.cs.vt.edu/corgis/json/airlines/airlines.json)
+* [Monthly Airline Delays by Airport, 2003-2016](https://think.cs.vt.edu/corgis/datasets/json/airlines/airlines.json)
 * FAA Airport Status
   * [SFO](http://services.faa.gov/airport/status/SFO?format=application/json)
   * [LAX](http://services.faa.gov/airport/status/LAX?format=application/json)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ _Sponsored link:_ [Front End Developer Jobs](https://www.bootstrapcdn.com/jobs/?
   * [ABC Local Stations](http://data.gov.au/geoserver/abc-local-stations/wfs?request=GetFeature&typeName=ckan_d534c0e9_a9bf_487b_ac8f_b7877a09d162&outputFormat=json)
   * [VIC Police Station Locations](http://data.gov.au/geoserver/police-station-locations/wfs?request=GetFeature&typeName=762b47b2_e706_4cab_b0c7_cf8e406aefc1&outputFormat=json)
   * [Museums Victoria Collections](https://collections.museumvictoria.com.au/api/search)
-* [Amsterdam](https://api.data.amsterdam.nl/api/) ([Google translation](https://translate.google.com/translate?sl=nl&tl=en&u=https%3A%2F%2Fapi.data.amsterdam.nl%2Fapi%2F))
 * Spain
   * [Province of Madrid Municipalities](https://datos.comunidad.madrid/catalogo/dataset/032474a0-bf11-4465-bb92-392052962866/resource/301aed82-339b-4005-ab20-06db41ee7017/download/municipio_comunidad_madrid.json)
   * [Province of Barcelona Municipalities](https://do.diba.cat/api/dataset/municipis/format/json2)

--- a/README.md
+++ b/README.md
@@ -196,31 +196,6 @@ _Sponsored link:_ [Front End Developer Jobs](https://www.bootstrapcdn.com/jobs/?
 
 ## Population
 
-* Total Population Today
-  * [Earth](http://api.population.io/1.0/population/World/today-and-tomorrow/?format=json)
-  * [Brazil](http://api.population.io/1.0/population/Brazil/today-and-tomorrow/?format=json)
-  * [France](http://api.population.io/1.0/population/France/today-and-tomorrow/?format=json)
-  * [Germany](http://api.population.io/1.0/population/Germany/today-and-tomorrow/?format=json)
-  * [Greece](http://api.population.io/1.0/population/Greece/today-and-tomorrow/?format=json)
-  * [Italy](http://api.population.io/1.0/population/Italy/today-and-tomorrow/?format=json)
-  * [Japan](http://api.population.io/1.0/population/Japan/today-and-tomorrow/?format=json)
-  * [Kenya](http://api.population.io/1.0/population/Kenya/today-and-tomorrow/?format=json)
-  * [Mexico](http://api.population.io/1.0/population/Mexico/today-and-tomorrow/?format=json)
-  * [Poland](http://api.population.io/1.0/population/Poland/today-and-tomorrow/?format=json)
-  * [India](http://api.population.io/1.0/population/India/today-and-tomorrow/?format=json)
-  * [United States](http://api.population.io/1.0/population/United%20States/today-and-tomorrow/?format=json)
-
-> Pro Tip: [List of all Countries](http://api.population.io/1.0/countries) tracked
-
-* United States Population Table (Ages 0-100)
-    * [1950](http://api.population.io/1.0/population/1950/United%20States/?format=json)
-    * [1960](http://api.population.io/1.0/population/1960/United%20States/?format=json)
-    * [1970](http://api.population.io/1.0/population/1970/United%20States/?format=json)
-    * [1980](http://api.population.io/1.0/population/1980/United%20States/?format=json)
-    * [1990](http://api.population.io/1.0/population/1990/United%20States/?format=json)
-    * [2000](http://api.population.io/1.0/population/2000/United%20States/?format=json)
-    * [2010](http://api.population.io/1.0/population/2010/United%20States/?format=json)
-
 * Historical Population (Since 1960)
   * [China](http://api.worldbank.org/countries/CHN/indicators/SP.POP.TOTL?per_page=5000&format=json)
   * [India](http://api.worldbank.org/countries/IND/indicators/SP.POP.TOTL?per_page=5000&format=json)


### PR DESCRIPTION
## Discontinued

- [jsonvat.com](https://jsonvat.com)
- [p-stats.com](http://api.bf4stats.com/api/onlinePlayers?output=json) (bf4stats.com)
- [lobbyfacts.eu](https://api.lobbyfacts.eu) (No longer offers public API, website uses SSR)

## Requires authentication 

- trade.gov
- Global Airfields
- population.io

## Updated links

- Monthly Airline Delays
- Amsterdam API

## Other
- It looks like the Magic the Gathering (mtgjson.com) links are broken as well, but the [API docs](https://mtgjson.com/) are still up. I don't play this game so I didn't know how to find replacements for those particular links.

Closes #212.